### PR TITLE
fix: hide get-involved events when it's empty

### DIFF
--- a/theme/Shared/_GetInvolved.cshtml
+++ b/theme/Shared/_GetInvolved.cshtml
@@ -8,24 +8,27 @@
 <div class="page-wrapper bg-light">
     @{Html.RenderPartial("Partials/_HeaderCarousel");}
 
-    <div class="banner">
-        <div class="container">
-            <h1>Auditions, workshops and socials</h1>
-        </div>
-    </div>
-
-    <div class="events-section">
-        <div class="container">
-            <div class="row">
-            @{
-                foreach(var eventItem in Documents["UpcomingEvents"])
-                {
-                    Html.RenderPartial("Partials/_EventCard", @eventItem);
-                }
-            }
+    @if(Documents["UpcomingEvents"].Any())
+    {
+        <div class="banner">
+            <div class="container">
+                <h1>Auditions, workshops and socials</h1>
             </div>
         </div>
-    </div>
+
+        <div class="events-section">
+            <div class="container">
+                <div class="row">
+                @{
+                    foreach(var eventItem in Documents["UpcomingEvents"])
+                    {
+                        Html.RenderPartial("Partials/_EventCard", @eventItem);
+                    }
+                }
+                </div>
+            </div>
+        </div>
+    }
 
     <div class="banner">
         <div class="container">


### PR DESCRIPTION
fixes #486 