### PR TITLE
Tactical fix to give Flickr Embedded Galleries height

### DIFF
--- a/input/shows/2020-the-musical-of-musicals-the-musical.md
+++ b/input/shows/2020-the-musical-of-musicals-the-musical.md
@@ -36,11 +36,11 @@ sections:
       **PRODUCER** | Clare Harding\
       **LEAD CHOREOGRAPHER** | Deborah Lean\
       **GUEST CHOREOGRAPHERS** | Danielle Capretti, Mary Bennett, Olivier Namet\
-      **ASSISTANT DIRECTOR** |Chris Foxwell\
+      **ASSISTANT DIRECTOR** | Chris Foxwell\
       **LIGHTING DESIGNER** | Martin Walton\
       **COSTUME DESIGNER** | Frederica Byron\
-      **SOUND DESIGNER** |Henry Whittaker\
-      **STAGE MANAGER** |Shiri Stern\
+      **SOUND DESIGNER** | Henry Whittaker\
+      **STAGE MANAGER** | Shiri Stern\
       **COMMITTEE LIAISON** | Olly Levett
 
       <!--EndFragment-->

--- a/theme/assets/css/shows/_shows.scss
+++ b/theme/assets/css/shows/_shows.scss
@@ -38,3 +38,7 @@
         height: 100%;
     }
 }
+
+iframe.flickr-embed-frame {
+    height: 427px !important;
+}


### PR DESCRIPTION
Fixes #575 

Implies that we only ever have 600 x 427 galleries in shows. We likely need to circle back and "do it properly" at some point. 