### PR TITLE
Use a personal access token to work around github

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,7 +24,7 @@ jobs:
       - name: automerge
         uses: "pascalgn/automerge-action@7ab42e888a333bf77ce865bc84fedc6a365a3548"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.ACTIONS_PAT }}"
           MERGE_METHOD: "squash"
           UPDATE_METHOD: "rebase"
           MERGE_DELETE_BRANCH: true


### PR DESCRIPTION
Kinda a WIP, trying to figure out why post auto-merge, master isn't auto building

As per 

>Note: You cannot trigger new workflow runs using the GITHUB_TOKEN. For more information, see "Triggering new workflows using a personal access token."

https://help.github.com/en/actions/reference/events-that-trigger-workflows

I've set up a PAT