### PR TITLE
fix: order news articles by date then title

### DIFF
--- a/theme/Shared/_News.cshtml
+++ b/theme/Shared/_News.cshtml
@@ -11,6 +11,7 @@
     @{
         var latestNews = Documents["News"]
             .OrderByDescending(article => article.Get<DateTime>("date"))
+            .ThenBy(article => article["title"])
             .Take(8);
 
         <div class="banner">

--- a/theme/Shared/_NewsArticle.cshtml
+++ b/theme/Shared/_NewsArticle.cshtml
@@ -10,7 +10,13 @@
     </div>
     <div class="col-md-4 news-article-details-column pt-3">
         <h3>More news</h3>
-        @foreach(var article in Documents["News"].Where(x => Model["title"] != x["title"]).OrderByDescending(x => x["date"]).Take(4))
+        
+        @foreach(var article in Documents["News"]
+            .Where(article => Model["title"] != article["title"])
+            .OrderByDescending(article => article.Get<DateTime>("date"))
+            .ThenBy(article => article["title"])
+            .Take(4)
+        )
         {
             <a href="@Context.GetLink(article as IDocument)"><h6>@article["title"]</h6></a>
         }


### PR DESCRIPTION
to ensure they don't reorder randomly

fixes #661 