### PR TITLE
build: fix build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ config\.wyam\.packages\.xml
 packages/
 
 node_modules
+
+cypress/screenshots
+cypress/videos

--- a/README.md
+++ b/README.md
@@ -22,10 +22,17 @@ build.ps1 -Target Preview
 ```
 
 ## Testing
+
+#### Pre-requisites
+- `npm` is installed an executable
+- `npx` is installed (`npm install -g npx`)
+- `cypress` is executable (`npx cypress verify`)
+
+#### Run
 - there's a small suite of Cypress tests, that can be run through
 - `npm i`
 - starting a dev server, either through the preview command, or with `npx serve -p 5080 output`, assuming the site has been built already
-- `npx cypress`
+- `npx cypress run`
 
 On any platform the site should then be available on [localhost:5080](http://localhost:5080).
 

--- a/config.wyam
+++ b/config.wyam
@@ -94,7 +94,7 @@ Pipelines.Add("News",
     Meta("category", "news"),
     Meta("background-override", "bg-turquoise"),
     Razor().WithViewStart("Layout/_NewsArticleViewStart.cshtml"),
-    WriteFiles(".html")
+    WriteFiles(".html").UseWriteMetadata(false)
 );
 
 Pipelines.Add("Events",

--- a/cypress/integration/news.spec.js
+++ b/cypress/integration/news.spec.js
@@ -1,0 +1,17 @@
+describe("news pages", () => {
+    it("should visit the news page", () => {
+        cy.visit("http://localhost:5080/news");
+    });
+
+    it("can select a news article", () => {
+        cy.visit("http://localhost:5080/news");
+        cy.get(".news-card").first().click();
+        cy.url().should('match', /news\/\d{4}-\d{2}-\d{2}-\s*/);
+    });
+
+    it("can select more news from a news article", () => {
+        cy.visit("http://localhost:5080/news");
+        cy.get(".news-card").first().click();
+        cy.get(".news-article-details-column a h6").first().click();       
+    })
+});


### PR DESCRIPTION
I believe this resolves #671 

As the Cypress tests now show, we _do_ need the initial write (as @olevett points out) for the sidebar.

We have a small Cypress set added for the overall news page, selecting the first article, and then navigating from this to another article from the sidebar. 