### PR TITLE
fix: event ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# VSCode
+.vscode/

--- a/Pipelines/UpcomingEvents.cs
+++ b/Pipelines/UpcomingEvents.cs
@@ -15,8 +15,10 @@ namespace Sedos.Pipelines
             ProcessModules = new ModuleList
             {
                 new ReplaceDocuments(nameof(Events)),
-                new FilterDocuments(Config.FromDocument((doc, ctx) =>doc.Get("times", Enumerable.Empty<IDocument>()).Any(time => time.Get<DateTime>("time") > DateTime.Now))),
-                new OrderDocuments(Config.FromDocument((doc, ctx) => doc.Get("times", Enumerable.Empty<IDocument>()).Select(time => time.Get<DateTime>("time")).First()))
+                new FilterDocuments(Config.FromDocument((doc, ctx) => doc.Get("times", Enumerable.Empty<IDocument>()).Any(time => time.Get<DateTime>("time") > DateTime.Now))),
+                new OrderDocuments(Config.FromDocument((doc, ctx) => doc.Get("times", Enumerable.Empty<IDocument>())
+                        .Select(time => time.Get<DateTime>("time"))
+                        .First(time => time > DateTime.Now)))
             };
         }
     }

--- a/theme/index.cshtml
+++ b/theme/index.cshtml
@@ -8,7 +8,7 @@ title: Sedos
         @{
             var upcomingShows = Outputs.FromPipeline("AllShows")
                     .Where(doc => doc.Get("showtimes", Enumerable.Empty<IDocument>()).Any(time => time.Get<DateTime>("time") > DateTime.Now))
-                    .OrderBy(doc => doc.Get<IEnumerable<IDocument>>("showtimes").Select(time => time.Get<DateTime>("time")).First())
+                    .OrderBy(doc => doc.Get<IEnumerable<IDocument>>("showtimes").Select(time => time.Get<DateTime>("time")).First(time => time > DateTime.Now))
                     .Take(3);
 
             var showOnHomePageShows = Outputs.FromPipeline("AllShows")


### PR DESCRIPTION
Fixes #818 

Orders Upcoming Events and Shows on homepage by dates only in the future; not the first time after filtering if _any_ date is in the future. 