### PR TITLE
feat: remove trailing youtube urls

### DIFF
--- a/input/shows/2010-hapgood.md
+++ b/input/shows/2010-hapgood.md
@@ -53,7 +53,7 @@ sections:
 
       <div class="video-responsive"><?# YouTube j7H83yVTUAw /?></div>
 
-      <div class="video-responsive"><?# YouTube f0eF_C9uOpQ&t=7s /?></div>
+      <div class="video-responsive"><?# YouTube f0eF_C9uOpQ /?></div>
 
       <div class="video-responsive"><?# YouTube fiJ2x390FzY /?></div>
 

--- a/input/shows/2014-into-the-woods.md
+++ b/input/shows/2014-into-the-woods.md
@@ -70,17 +70,17 @@ sections:
   - order: 3
     title: VIDEO
     body: |-
-      <div class="video-responsive"><?# YouTube gbapd8JZ0fM&t=13s /?></div>
+      <div class="video-responsive"><?# YouTube gbapd8JZ0fM /?></div>
 
-        
+
 
       <div class="video-responsive"><?# YouTube MlUNpnKljxs /?></div>
 
-        
+
 
       <div class="video-responsive"><?# YouTube oGAn4utSwfA /?></div>
 
-        
+
 
       <div class="video-responsive"><?# YouTube _m5Xa970adw /?></div>
   - order: 4

--- a/input/shows/2020-lets-talk-about-scripts.md
+++ b/input/shows/2020-lets-talk-about-scripts.md
@@ -29,7 +29,7 @@ sections:
     body: |-
       <div class="video-responsive"><?# YouTube -nuCG6O-s48 /?></div>
 
-      <div class="video-responsive"><?# YouTube ulAgpkSYu0g&t=3s /?></div>
+      <div class="video-responsive"><?# YouTube ulAgpkSYu0g /?></div>
 
       <div class="video-responsive"><?# YouTube HAh24fsYUo8 /?></div>
 ---
@@ -46,9 +46,9 @@ For this series of casual readings, we've learned from our colleagues in other s
 * Rehearsals will take place via Zoom.
 * The performance will take place via Zoom on Thursdays at 7.30pm.
 
-While we can't guarantee a role to everyone who applies, we will aim to be fair and ensure no one misses out over the course of the season. Of course, anyone who isn't cast is encouraged to dial in for the performance. 
+While we can't guarantee a role to everyone who applies, we will aim to be fair and ensure no one misses out over the course of the season. Of course, anyone who isn't cast is encouraged to dial in for the performance.
 
- If you have any questions, please email Peter Foster at [readings@sedos.co.uk](mailto:readings@sedos.co.uk)[](http://r20.rs6.net/tn.jsp?f=001o3_SP7cheDBeX4G67bw5hStGYdO5HvXB0ptJeSKsbxaq5E55SoDoQ-rS2p0ZTbHyTW5G3dWcbdYQs9CRJ7bWSKaADV1Az8MQxK7e3mN8JcgXAAkYtD7lWac5czQ2aAU_5Z_5aADKW2FwgLcsfQUyWZW2ni6Qo8-pRuagxYZ8MCFhVv_L845pQw==&c=u5ghrGBx3MSJeIZDXOYVy5dH45VZCqqHHeHRNrVbUD3GhFp17VMnMg==&ch=KlhiVUVN7kiiGS2tXNwAXhSAgzx3UfswgOg6BljoMg-o9AhuTX91Ig==) 
+ If you have any questions, please email Peter Foster at [readings@sedos.co.uk](mailto:readings@sedos.co.uk)[](http://r20.rs6.net/tn.jsp?f=001o3_SP7cheDBeX4G67bw5hStGYdO5HvXB0ptJeSKsbxaq5E55SoDoQ-rS2p0ZTbHyTW5G3dWcbdYQs9CRJ7bWSKaADV1Az8MQxK7e3mN8JcgXAAkYtD7lWac5czQ2aAU_5Z_5aADKW2FwgLcsfQUyWZW2ni6Qo8-pRuagxYZ8MCFhVv_L845pQw==&c=u5ghrGBx3MSJeIZDXOYVy5dH45VZCqqHHeHRNrVbUD3GhFp17VMnMg==&ch=KlhiVUVN7kiiGS2tXNwAXhSAgzx3UfswgOg6BljoMg-o9AhuTX91Ig==)
 
 We look forward to seeing you online soon.
 

--- a/input/shows/2020-the-importance-of-being-earnest.md
+++ b/input/shows/2020-the-importance-of-being-earnest.md
@@ -31,8 +31,8 @@ RedirectFrom:
 ---
 **Missed our live Zoom production of Wilde's trivial comedy for serious people, our first ever virtual play? Then you're in luck as it's now available to watch again online.**
 
-Pass the cucumber sandwiches and pour yourself a cup of tea. Our rehearsed reading of Oscar Wilde's trivial comedy for serious people, *The Importance of Being Earnest*, is available to watch again online. 
+Pass the cucumber sandwiches and pour yourself a cup of tea. Our rehearsed reading of Oscar Wilde's trivial comedy for serious people, *The Importance of Being Earnest*, is available to watch again online.
 
 Directed by Lloyd Smith with a cast of eight, this delicious farcical comedy, in which the protagonists maintain fictitious personae to escape burdensome social obligations, was watched by 100 people when it went out during lockdown on Zoom on Friday 17 April 2020.
 
-<div class="video-responsive"><?# YouTube xv_-iUU4NG8&t=4s /?></div>
+<div class="video-responsive"><?# YouTube xv_-iUU4NG8 /?></div>

--- a/input/shows/2021-masked-sedos-singer-season-2.md
+++ b/input/shows/2021-masked-sedos-singer-season-2.md
@@ -78,7 +78,7 @@ sections:
       Liberty - revealed as Chloë Faine
 
       ^^^ ![](/assets/heat-1-copy.jpg)
-      ^^^ 
+      ^^^
 
       ^^^ ![](/assets/heat-2-copy.jpg)
       ^^^
@@ -91,13 +91,13 @@ sections:
       first round and final performances below.
 
 
-      <div class="video-responsive"><?# YouTube SWKzWLGW0kM&t=2s /?></div>
+      <div class="video-responsive"><?# YouTube SWKzWLGW0kM /?></div>
 
 
       <div class="video-responsive"><?# YouTube ZsN97eTYs4Y /?></div>
 
 
-      <div class="video-responsive"><?# YouTube jpQjhIGcjJA&t=7s /?></div>
+      <div class="video-responsive"><?# YouTube jpQjhIGcjJA /?></div>
 ---
 **After the success of [Season 1](https://sedos.co.uk/shows/2021-masked-sedos-singer), Masked Sedos Singer is back for Season 2.**
 

--- a/input/shows/2021-masked-sedos-singer.md
+++ b/input/shows/2021-masked-sedos-singer.md
@@ -83,19 +83,19 @@ sections:
       Visit our [Facebook live
       replays](https://www.facebook.com/sedostheatre/live_videos/) to see both
       heats and the final in full or watch a quick recap of all the contestants'
-      first round and final performances below. 
+      first round and final performances below.
 
 
       <div class="video-responsive"><?# YouTube SXIGKO70LjI /?></div>
 
 
-      <div class="video-responsive"><?# YouTube POuxfiTMK6w&feature=youtu.be /?></div>
+      <div class="video-responsive"><?# YouTube POuxfiTMK6w /?></div>
 ---
 **Disguised Sedos members go head to head in the Masked Sedos Singer – can you guess who is in the costume?**
 
-Our judges will plunder their Sedos knowledge to try to work out the identity of our performers and you can get involved too. 
+Our judges will plunder their Sedos knowledge to try to work out the identity of our performers and you can get involved too.
 
-There will be two heats on Tuesday 16 and Wednesday 17 February leading up to a grand final on Tuesday 9 March. 
+There will be two heats on Tuesday 16 and Wednesday 17 February leading up to a grand final on Tuesday 9 March.
 
 Ultimately, it's the audience's decision who makes it through to the final – and who is crowned the winner – so get ready to vote for your favourite.
 


### PR DESCRIPTION
this is breaking #923 because something has changed subtly within the YouTube parsing library, and any of the trailing config stuff is disallowed. Looking at the videos I've changed it doesn't seem particularly important!