### PR TITLE
feat: adjust size of carousel indicators dynamically

### DIFF
--- a/theme/assets/css/home-page/_hero-carousel.scss
+++ b/theme/assets/css/home-page/_hero-carousel.scss
@@ -23,9 +23,9 @@
 
     .carousel-indicators {
         bottom: -130px;
+        margin-left: 0;
+        margin-right: 0;
         overflow-x: initial;
-        margin-left: 0px;
-        margin-right: 0px;
 
         li {
             height: 100px;


### PR DESCRIPTION
fixes #1409

In theory, these should have flexboxed, but because of where the width/height were set weren't going to 

On narrow screens, we'll end up with this, which I think is _fine_
![image](https://user-images.githubusercontent.com/8627917/142198097-cc426a0c-ff36-460b-9855-4e64e3d9aa18.png)

