### PR TITLE
Move Body Block

### DIFF
--- a/theme/Shared/_WhatsOn.cshtml
+++ b/theme/Shared/_WhatsOn.cshtml
@@ -12,16 +12,6 @@
         </div>
     </div>
 
-    <div class="page-section">
-        <div class="container bg-light">
-            <div class="row">
-                <div class="col">
-                    @RenderBody()
-                </div>
-            </div>
-        </div>
-    </div>
-
     <div class="upcoming-shows-section">
         <div>
             @{
@@ -54,6 +44,15 @@
                             View past productions
                         </a>
                     </p>
+                </div>
+            </div>
+        </div>
+        <div class="page-section">
+            <div class="container bg-light">
+                <div class="row">
+                    <div class="col">
+                        @RenderBody()
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
> Please can the copy go below the show flyers/links, rather than above? Apologies if that wasn't clear anywhere - we definitely envisaged this going below the shows so it did its SEO job/was there if anyone wanted to read it, but the show flyers/links remain the top thing.
