### PR TITLE
feat: don't append random id to images

### DIFF
--- a/Extensions/CopyAndResizeHeaderImage.cs
+++ b/Extensions/CopyAndResizeHeaderImage.cs
@@ -27,7 +27,7 @@ namespace Sedos.Extensions
                 new ModuleList
                 {
                     new ReadFiles(filename),
-                    new MutateImage().Resize(width: width, height: height, mode: resizeMode).SetSuffix(doc.Id.ToString()),
+                    new MutateImage().Resize(width: width, height: height, mode: resizeMode),
                     new WriteFiles()
                 },
                 new IDocument[] { doc }


### PR DESCRIPTION
we needed to do this at one point because Statiq was doing something odd/clashing file wise, I wanted to check it was still necessary before going down a rabbit hole of optimisations