### PR TITLE
bug: fix tabs on show pages after bootstrap update

### DIFF
--- a/theme/Shared/_Show.cshtml
+++ b/theme/Shared/_Show.cshtml
@@ -1,4 +1,5 @@
 @using Statiq.Common;
+@using System.Text.RegularExpressions;
 @using Sedos.Extensions;
 @model IDocument
 
@@ -16,19 +17,20 @@
             <div class="col-md-8 pt-3" role="tabpanel">
                 <ul class="nav nav-tabs show-nav" role="tablist" id="showDetailsTab">
                     <li class="nav-item">
-                        <a class="nav-link active show-details-nav-header" id="details-tab" data-bs-toggle="tab" href="#details" role="tab" aria-controls="details" aria-expanded="false">Details</a>
+                        <button class="nav-link active show-details-nav-header" id="details-tab" data-bs-toggle="tab" data-bs-target="#details" role="tab" aria-controls="details" aria-selected="true">Details</button>
                     </li>
                     @{
                         foreach (var document in Model.Get("sections", Enumerable.Empty<IDocument>()))
                         {
+                            var safeTitle = Regex.Replace(document["title"].ToString(), "[^A-Za-z0-9]", "").ToLower();
                             <li class="nav-item">
-                                <a class="nav-link show-details-nav-header" id="@document["title"]-tab" data-bs-toggle="tab" href="#@document["title"]" role="tab" aria-controls="@document["title"]" aria-expanded="false">@document["title"]</a>
+                                <button class="nav-link show-details-nav-header" id="@safeTitle-tab" data-bs-toggle="tab" data-bs-target="#@safeTitle" role="tab" aria-controls="@safeTitle" aria-selected="false">@document["title"]</button>
                             </li>
                         }
                     }
                 </ul>
                 <div class="tab-content" id="showDetailsTabContent">
-                    <div role="tabpanel" class="tab-pane fade active show" id="details" aria-labelledby="details-tab" aria-expanded="false">
+                    <div role="tabpanel" class="tab-pane fade active show" id="details" aria-labelledby="details-tab">
                         <p>
                             @RenderBody()
                         </p>
@@ -36,7 +38,8 @@
                     @{
                         foreach (var document in Model.Get("sections", Enumerable.Empty<IDocument>()))
                         {
-                            <div class="tab-pane fade" id="@document["title"]" role="tabpanel" aria-labelledby="@document["title"]-tab" aria-expanded="true">
+                            var safeTitle = Regex.Replace(document["title"].ToString(), "[^A-Za-z0-9]", "").ToLower();
+                            <div class="tab-pane fade" id="@safeTitle" role="tabpanel" aria-labelledby="@safeTitle-tab">
                                 <div class="pt-3">
                                     @Html.Raw(document["body"])
                                 </div>


### PR DESCRIPTION
The tabs were broken after the update to Bootstrap - it appears the IDs are checked for validity - which ours weren't being the title of the document section. 

We've moved from `<a>` to `<button>` based on [the docs for 5.0](https://getbootstrap.com/docs/5.0/components/navs-tabs/#javascript-behavior)

I'd like to update all the show files to actually generate a "definitely" URL safe version of the title and save it so we don't have to compute it each time (e.g at the moment the RegEx would allow a starting digit).

This is a quick fix to make them work again before we can think of the smarter longer term solution.