### PR TITLE
chore: remove google tag manager for only ga4 configuration

### DIFF
--- a/theme/Shared/_Default.cshtml
+++ b/theme/Shared/_Default.cshtml
@@ -2,10 +2,6 @@
 <html lang="en">
   @Html.Partial("Partials/_Head")
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe title="google tag manager injection" src="https://www.googletagmanager.com/ns.html?id=GTM-PG6KHFD"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
     @Html.Partial("Partials/_Navigation")
     <div class="main-wrapper">
         @RenderBody()


### PR DESCRIPTION
Remove Google Tag Manager for only the GA4 setup