### PR TITLE
chore: add retry step

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,7 +26,11 @@ jobs:
     - name: Build
       run: dotnet build /p:RestorePackagesWithLockFile=true
     - name: Run
-      run: dotnet run deploy
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        command: dotnet run deploy
     - name: Node Install
       run: 'npm ci'
     - name: Lint Styles

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,11 @@ jobs:
     - name: Build
       run: dotnet build /p:RestorePackagesWithLockFile=true
     - name: Run
-      run: dotnet run deploy
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        command: dotnet run deploy
     - name: Node Install
       run: 'npm ci'
     - name: Lint Styles


### PR DESCRIPTION
Add a retry step to the build, whilst investigating the transient build failures. This hopefully will reduce the number of times non-GitHub users ask about the status of the build when it has failed for reasons outside their control. 