### PR TITLE
Replace s0/git-publish-subdir-action with JamesIves/github-pages-depl…

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -11,6 +11,9 @@ on:
 concurrency:
   group: deploy
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build and publish
@@ -46,9 +49,7 @@ jobs:
         start: 'npx serve -p 5080 output'
         wait-on: 'http://localhost:5080'
     - name: Deploy
-      uses: s0/git-publish-subdir-action@v2.6.0
-      env:
-        REPO: self
-        BRANCH: gh-pages
-        FOLDER: output
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages
+        folder: output


### PR DESCRIPTION
…oy-action

Swap the failing deploy step for the actively maintained JamesIves/github-pages-deploy-action, keeping the same gh-pages branch deployment. Add an explicit contents:write permission so the deploy can push regardless of the repo's default GITHUB_TOKEN setting.