### PR TITLE
Enrich TheaterEvent JSON-LD for Google Search discovery

### DIFF
--- a/Helpers/JsonLD.cs
+++ b/Helpers/JsonLD.cs
@@ -18,34 +18,52 @@ namespace Sedos.Helpers
             }.Uri
         };
 
-        public static string Show(IDocument doc, IReadOnlyCollection<IDocument> venues)
+        // Rough running time used to derive an endDate for individual
+        // performances when none is provided in frontmatter.
+        private static readonly TimeSpan PerformanceDuration = TimeSpan.FromHours(2.5);
+
+        private static readonly PerformingGroup SedosPerformer = new()
         {
-            DateTimeOffset? startDate = doc.Get("showtimes", Enumerable.Empty<IDocument>()).Any()
-                ? doc.Get("showtimes", Enumerable.Empty<IDocument>()).Select(x => x.Get<DateTimeOffset>("time")).OrderBy(x => x).FirstOrDefault()
-                : null;
+            Name = Constants.Sedos
+        };
+
+        public static string Show(IDocument doc, IReadOnlyCollection<IDocument> venues, string url)
+        {
+            var showtimes = doc.Get("showtimes", Enumerable.Empty<IDocument>())
+                .Select(x => x.Get<DateTimeOffset>("time"))
+                .OrderBy(x => x)
+                .ToList();
+
+            DateTimeOffset? startDate = showtimes.Any() ? showtimes.First() : null;
+            DateTimeOffset? endDate = showtimes.Any() ? showtimes.Last() : null;
 
             var location = GeneratePlace(doc.GetString("venue"), venues);
             var flyer = GenerateImage(doc.GetString("flyer"));
+            var offer = GenerateOffer(doc);
 
+            var theaterEvent = BuildEvent(doc, url, startDate, endDate, location, flyer, offer);
+            theaterEvent.SubEvent = new OneOrMany<IEvent>(showtimes.Select(x =>
+                BuildEvent(doc, url, x, x + PerformanceDuration, location, flyer, offer)));
+
+            return theaterEvent.ToHtmlEscapedString();
+        }
+
+        private static TheaterEvent BuildEvent(IDocument doc, string url, DateTimeOffset? startDate, DateTimeOffset? endDate, Place location, Uri flyer, Offer offer)
+        {
             return new TheaterEvent()
             {
                 Name = doc.Get("title", ""),
+                Url = url != null ? new Uri(url) : null,
                 StartDate = startDate,
+                EndDate = endDate,
                 Location = location,
                 Description = doc.Get("metaDescription", ""),
                 Organizer = SedosOrganization,
+                Performer = SedosPerformer,
                 Image = flyer,
-                Offers = GenerateOffer(doc),
-                SubEvent = new OneOrMany<IEvent>(doc.Get("showtimes", Enumerable.Empty<IDocument>()).Select(x => x.Get<DateTimeOffset>("time")).Select(x => new TheaterEvent()
-                {
-                    Name = doc.GetString("title", ""),
-                    StartDate = x,
-                    Location = location,
-                    Description = doc.Get("metaDescription", ""),
-                    Organizer = SedosOrganization,
-                    Image = flyer
-                }))
-            }.ToHtmlEscapedString();
+                EventStatus = EventStatusType.EventScheduled,
+                Offers = offer
+            };
         }
 
         private static Place GeneratePlace(string venueName, IReadOnlyCollection<IDocument> venues)
@@ -90,11 +108,20 @@ namespace Sedos.Helpers
             if (endDate >= DateTime.Today && show.GetBool("box-office-open", false))
             {
                 var bookingLink = BoxOfficeUri.FromBoxOfficeLink(show.GetString("box-office-link"));
-                return new Offer
+                var offer = new Offer
                 {
                     Url = bookingLink,
-                    PriceCurrency = "GBP"
+                    PriceCurrency = "GBP",
+                    Availability = ItemAvailability.InStock
                 };
+
+                var price = show.GetString("price");
+                if (!string.IsNullOrWhiteSpace(price))
+                {
+                    offer.Price = price;
+                }
+
+                return offer;
             }
 
             return null;

--- a/Pipelines/AllShows.cs
+++ b/Pipelines/AllShows.cs
@@ -27,12 +27,12 @@ namespace Sedos.Pipelines
                     Task.WhenAll(doc.Get("sections", Enumerable.Empty<IDocument>())
                         .OrderBy(d => d.Get("order", 1))
                         .Select(d => MarkdownExtensions.ProcessMarkdownAsync(d, ctx))))),
-                new SetMetadata("jsonLd", Config.FromDocument((doc, ctx) => JsonLD.Show(doc, ctx.Outputs.FromPipeline(nameof(Venues))))),
+                new SetDestination(".html"),
+                new SetMetadata("jsonLd", Config.FromDocument((doc, ctx) => JsonLD.Show(doc, ctx.Outputs.FromPipeline(nameof(Venues)), doc.GetLink(true)))),
                 MarkdownExtensions.MarkdownRenderer(),
                 new RenderRazor()
                     .WithViewStart("Layout/_ShowViewStart.cshtml"),
                 new ProcessShortcodes(),
-                new SetDestination(".html"),
             };
 
             OutputModules = new ModuleList

--- a/input/admin/config.yml
+++ b/input/admin/config.yml
@@ -83,6 +83,11 @@ collections:
         name: ticket-prices
         widget: text
         required: false
+      - label: Lowest ticket price (number only, GBP - used for search engine structured data)
+        name: price
+        widget: number
+        value_type: float
+        required: false
       - label: Additional Ticket Information
         name: additional-ticket-info
         widget: text

--- a/input/shows/2026-angels-in-america.md
+++ b/input/shows/2026-angels-in-america.md
@@ -20,6 +20,7 @@ showtimes:
 showtime-summary: 19-28 NOVEMBER 2026
 venue: Bridewell Theatre
 ticket-prices: Tickets from £18 for both parts (no booking fee)
+price: "18"
 primary-color: "#567b85"
 header-image: /assets/website-homepage-image-angelsinamerica.jpg
 header-image-contain: false

--- a/input/shows/2026-be-more-chill.md
+++ b/input/shows/2026-be-more-chill.md
@@ -15,6 +15,7 @@ showtimes:
   - time: 2026-10-24 19:30
 showtime-summary: 20-24 OCTOBER 2026
 ticket-prices: Tickets from £14 (no booking fee)
+price: "14"
 primary-color: "#8a4b99"
 header-image: /assets/be-more-chill-1791-x-1391-px-1-.png
 header-image-contain: false

--- a/input/shows/2026-brighton-beach-memoirs.md
+++ b/input/shows/2026-brighton-beach-memoirs.md
@@ -14,6 +14,7 @@ showtimes:
 showtime-summary: 8-12 SEPTEMBER 2026
 venue: Bridewell Theatre
 ticket-prices: Tickets from £12.50 (no booking fee)
+price: "12.50"
 primary-color: "#ac3e0b"
 header-image: /assets/brighton-beach-memoirs-baseball-image-800.jpg
 header-image-contain: false

--- a/input/shows/2026-loves-labours-lost.md
+++ b/input/shows/2026-loves-labours-lost.md
@@ -16,6 +16,7 @@ showtimes:
 showtime-summary: 15-19 SEPTEMBER 2026
 venue: Bridewell Theatre
 ticket-prices: Tickets from £14 (no booking fee)
+price: "14"
 primary-color: "#5c8dac"
 header-image: /assets/lll-web-header.png
 header-image-contain: false

--- a/input/shows/2026-the-curious-incident-of-the-dog-in-the-night-time.md
+++ b/input/shows/2026-the-curious-incident-of-the-dog-in-the-night-time.md
@@ -14,6 +14,7 @@ showtimes:
 showtime-summary: 14-18 JULY 2026
 venue: Bridewell Theatre
 ticket-prices: Tickets from £12.50 (no booking fee)
+price: "12.50"
 primary-color: "#fed943"
 header-image: /assets/curious-incident-website.jpg
 header-image-contain: false


### PR DESCRIPTION
## Why

Show pages already emit `TheaterEvent` JSON-LD (PR #753) with all of Google''s **required** Event properties, but shows still aren''t appearing as Event rich results in Google Search/Maps (#3996). Two root causes:

1. **No `url` on the events** — Google needs a unique URL to associate the structured data with a discoverable page. The JSON-LD was also generated *before* `SetDestination(.html)`, so the link resolved against the `.md` source path.
2. **Missing recommended properties** Google uses to decide whether to *display* a valid result (`eventStatus`, `endDate`, `performer`, richer `offers`).

## What

- **`Pipelines/AllShows.cs`** — move `SetDestination(.html)` before the `jsonLd` metadata step so `doc.GetLink(true)` resolves to the absolute canonical URL (same pattern as `Sitemap.cs`); pass it into `JsonLD.Show`.
- **`Helpers/JsonLD.cs`** — extract a shared `BuildEvent` helper and add:
  - `url` (absolute page URL)
  - `eventStatus` = `EventScheduled`
  - `performer` = Sedos `PerformingGroup`
  - `endDate` (run end on parent; per-performance estimate on subEvents)
  - `offers` on **every** subEvent (was parent-only), with `availability` = `InStock` and `price` from a new frontmatter field
- **`input/admin/config.yml`** — add an editable `price` number field to the shows collection.
- **Five upcoming 2026 show files** — populate `price`.

> Note: `eventAttendanceMode` is intentionally omitted — Schema.NET 13.0.0 doesn''t expose that property, and it''s optional (not worth a major dependency bump).

## Verification

- `dotnet build` clean.
- Generated the site and confirmed the JSON-LD for upcoming shows now includes absolute `url`, `eventStatus`, `endDate`, `performer`, and a full `offers` block (`price`/`priceCurrency`/`availability`/`url`) on both the parent and all subEvents.
- Past shows (e.g. `2025-assassins`) correctly omit `offers` (box office closed) while keeping the other properties.

After merge/deploy: validate via the [Rich Results Test](https://search.google.com/test/rich-results) and monitor Google Search Console → Enhancements → Events.

Fixes #3996

🤖 Generated with [Claude Code](https://claude.com/claude-code)