### PR TITLE
Deep link directly to show detail tabs via URL hash

### DIFF
--- a/theme/Shared/_Show.cshtml
+++ b/theme/Shared/_Show.cshtml
@@ -108,3 +108,34 @@
         </div>
     </div>
 </div>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        var tabList = document.getElementById("showDetailsTab");
+        if (!tabList) {
+            return;
+        }
+
+        function activateFromHash() {
+            var hash = window.location.hash;
+            if (!hash) {
+                return;
+            }
+            var trigger = tabList.querySelector('button[data-bs-target="' + hash + '"]');
+            if (trigger) {
+                bootstrap.Tab.getOrCreateInstance(trigger).show();
+            }
+        }
+
+        // Open the matching tab on load and when the hash changes.
+        activateFromHash();
+        window.addEventListener("hashchange", activateFromHash);
+
+        // Reflect the active tab in the URL so it can be shared/deep linked.
+        tabList.querySelectorAll('button[data-bs-toggle="tab"]').forEach(function (btn) {
+            btn.addEventListener("shown.bs.tab", function (e) {
+                history.replaceState(null, "", e.target.getAttribute("data-bs-target"));
+            });
+        });
+    });
+</script>


### PR DESCRIPTION
Activates the matching details tab on page load (and on hashchange) when the URL contains a tab hash, e.g. #fromthedirector. Also updates the URL via replaceState when a tab is clicked so links are shareable.